### PR TITLE
feat: support custom key

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,37 @@ export default function App() {
 }
 ```
 
+### Using a custom object key
+
+The `r2.generateUploadUrl` function generates a uuid to use as the object key by
+default, but a custom key can be provided if desired. Note: the `generateUploadUrl`
+function returned by `r2.clientApi` does not accept a custom key, as that
+function is a mutation to be called from the client side and you don't want your
+client defining your object keys. Providing a custom key requires making your
+own mutation that calls the `generateUploadUrl` method of the `r2` instance.
+
+```ts
+// convex/example.ts
+import { R2 } from "@convex-dev/r2";
+import { components } from "./_generated/api";
+
+export const r2 = new R2(components.r2);
+
+// A custom mutation that creates a key from the user id and a uuid
+export const generateUploadUrlWithCustomKey = mutation({
+  args: {},
+  handler: async (ctx) => {
+    // Replace this with whatever function you use to get the current user
+    const currentUser = await getUser(ctx);
+    if (!currentUser) {
+      throw new Error("User not found");
+    }
+    const key = `${currentUser.id}.${crypto.randomUUID()}`;
+    return r2.generateUploadUrl(key);
+  },
+});
+```
+
 ## Serving Files
 Files stored in R2 can be served to your users by generating a URL pointing to a given file.
 

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -92,7 +92,7 @@ export class R2 {
     ) {
       throw new Error(
         "R2 configuration is missing required fields.\n" +
-          "R2_BUCKET, R2_ENDPOINT, R2_ACCESS_KEY_ID, R2_SECRET_ACCESS_KEY"
+        "R2_BUCKET, R2_ENDPOINT, R2_ACCESS_KEY_ID, R2_SECRET_ACCESS_KEY"
       );
     }
     this.r2 = createR2Client(this.r2Config);
@@ -116,8 +116,8 @@ export class R2 {
    *   - `key` - The R2 object key.
    *   - `url` - A signed URL for uploading the object.
    */
-  async generateUploadUrl() {
-    const key = crypto.randomUUID();
+  async generateUploadUrl(customKey?: string) {
+    const key = customKey ? customKey : crypto.randomUUID();
     const url = await getSignedUrl(
       this.r2,
       new PutObjectCommand({ Bucket: this.r2Config.bucket, Key: key })
@@ -348,12 +348,12 @@ export class R2 {
 
 export type OpaqueIds<T> =
   T extends GenericId<infer _T>
-    ? string
-    : T extends (infer U)[]
-      ? OpaqueIds<U>[]
-      : T extends object
-        ? { [K in keyof T]: OpaqueIds<T[K]> }
-        : T;
+  ? string
+  : T extends (infer U)[]
+  ? OpaqueIds<U>[]
+  : T extends object
+  ? { [K in keyof T]: OpaqueIds<T[K]> }
+  : T;
 
 export type UseApi<API> = Expand<{
   [mod in keyof API]: API[mod] extends FunctionReference<
@@ -363,12 +363,12 @@ export type UseApi<API> = Expand<{
     infer FReturnType,
     infer FComponentPath
   >
-    ? FunctionReference<
-        FType,
-        "internal",
-        OpaqueIds<FArgs>,
-        OpaqueIds<FReturnType>,
-        FComponentPath
-      >
-    : UseApi<API[mod]>;
+  ? FunctionReference<
+    FType,
+    "internal",
+    OpaqueIds<FArgs>,
+    OpaqueIds<FReturnType>,
+    FComponentPath
+  >
+  : UseApi<API[mod]>;
 }>;

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -92,7 +92,7 @@ export class R2 {
     ) {
       throw new Error(
         "R2 configuration is missing required fields.\n" +
-        "R2_BUCKET, R2_ENDPOINT, R2_ACCESS_KEY_ID, R2_SECRET_ACCESS_KEY"
+          "R2_BUCKET, R2_ENDPOINT, R2_ACCESS_KEY_ID, R2_SECRET_ACCESS_KEY"
       );
     }
     this.r2 = createR2Client(this.r2Config);
@@ -112,12 +112,13 @@ export class R2 {
   /**
    * Generate a signed URL for uploading an object to R2.
    *
+   * @param customKey (optional) - A custom R2 object key to use.
    * @returns A promise that resolves to an object with the following fields:
    *   - `key` - The R2 object key.
    *   - `url` - A signed URL for uploading the object.
    */
   async generateUploadUrl(customKey?: string) {
-    const key = customKey ? customKey : crypto.randomUUID();
+    const key = customKey || crypto.randomUUID();
     const url = await getSignedUrl(
       this.r2,
       new PutObjectCommand({ Bucket: this.r2Config.bucket, Key: key })
@@ -348,12 +349,12 @@ export class R2 {
 
 export type OpaqueIds<T> =
   T extends GenericId<infer _T>
-  ? string
-  : T extends (infer U)[]
-  ? OpaqueIds<U>[]
-  : T extends object
-  ? { [K in keyof T]: OpaqueIds<T[K]> }
-  : T;
+    ? string
+    : T extends (infer U)[]
+      ? OpaqueIds<U>[]
+      : T extends object
+        ? { [K in keyof T]: OpaqueIds<T[K]> }
+        : T;
 
 export type UseApi<API> = Expand<{
   [mod in keyof API]: API[mod] extends FunctionReference<
@@ -363,12 +364,12 @@ export type UseApi<API> = Expand<{
     infer FReturnType,
     infer FComponentPath
   >
-  ? FunctionReference<
-    FType,
-    "internal",
-    OpaqueIds<FArgs>,
-    OpaqueIds<FReturnType>,
-    FComponentPath
-  >
-  : UseApi<API[mod]>;
+    ? FunctionReference<
+        FType,
+        "internal",
+        OpaqueIds<FArgs>,
+        OpaqueIds<FReturnType>,
+        FComponentPath
+      >
+    : UseApi<API[mod]>;
 }>;


### PR DESCRIPTION
Allow custom key to be passed for uploaded files specially needed if file has to have .type or if user wants to seperate user buckets like userId/key etc.



<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
