### PR TITLE
add custom key to useUploadFile hook from the client

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Store and serve files with Cloudflare R2.
 const uploadFile = useUploadFile(api.example);
 // ...in a callback
 const key = await uploadFile(file);
+// You can also pass a custom key, if not a random uuid will be generated
+const key = await uploadFile(file, "my-custom-key");
 
 // Access files on the server
 const url = await r2.getUrl(key);

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -328,16 +328,18 @@ export class R2 {
        * Generate a signed URL for uploading an object to R2.
        */
       generateUploadUrl: mutationGeneric({
-        args: {},
+        args: {
+          customKey: v.optional(v.string()),
+        },
         returns: v.object({
           key: v.string(),
           url: v.string(),
         }),
-        handler: async (ctx) => {
+        handler: async (ctx, args) => {
           if (opts?.checkUpload) {
             await opts.checkUpload(ctx, this.config.bucket);
           }
-          return this.generateUploadUrl();
+          return this.generateUploadUrl(args.customKey);
         },
       }),
       /**

--- a/src/react/index.ts
+++ b/src/react/index.ts
@@ -10,17 +10,20 @@ import { ClientApi } from "../client";
  *
  * @param api - The client API object from the R2 component, including at least
  * `generateUploadUrl` and `syncMetadata`.
+ * @param customKey - An optional key to use for the uploaded file. If not
+ * provided, a random key will be generated.
  * @returns A function that uploads a file to R2.
  */
 export function useUploadFile(
-  api: Pick<ClientApi, "generateUploadUrl" | "syncMetadata">
+  api: Pick<ClientApi, "generateUploadUrl" | "syncMetadata">,
+  customKey?: string
 ) {
   const generateUploadUrl = useMutation(api.generateUploadUrl);
   const syncMetadata = useMutation(api.syncMetadata);
 
   return useCallback(
     async (file: File) => {
-      const { url, key } = await generateUploadUrl();
+      const { url, key } = await generateUploadUrl(customKey);
       try {
         const result = await fetch(url, {
           method: "PUT",


### PR DESCRIPTION
<!-- Describe your PR here. -->

This feature allows you to pass a custom key from the client in the `useUploadFile` hook.

E.g 
```ts
const time = new Date().getTime()
const myKey = `audio-sessions/audio/${time}`
const key = await uploadFile(file, myKey);
```

This extends the functionality of #2 and #4 

<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
