### PR TITLE
enhance getUrl method to accept optional expiration time for signed URLs

### DIFF
--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -144,12 +144,16 @@ export class R2 {
    * Get a signed URL for serving an object from R2.
    *
    * @param key - The R2 object key.
+   * @param options - Optional config object.
+   *   - `expiresIn` - The number of seconds until the URL expires (default: 3600, max: 604800 for 7 days).
    * @returns A promise that resolves to a signed URL for the object.
    */
-  async getUrl(key: string) {
+  async getUrl(key: string, options: { expiresIn?: number } = {}) {
+    const { expiresIn = 3600 } = options;
     return await getSignedUrl(
       this.r2,
-      new GetObjectCommand({ Bucket: this.config.bucket, Key: key })
+      new GetObjectCommand({ Bucket: this.config.bucket, Key: key }),
+      { expiresIn }
     );
   }
   /**


### PR DESCRIPTION
<!-- Describe your PR here. -->

This PR enhances the `R2.getUrl()` method to allow developers to configure the expiration time of presigned URLs for downloads. It introduces an optional options object with an `expiresIn` property (in seconds).

<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
