### PR TITLE
Pin @aws-sdk/client-s3 version temporarily

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
   "types": "./dist/commonjs/client/index.d.ts",
   "module": "./dist/esm/client/index.js",
   "dependencies": {
-    "@aws-sdk/client-s3": "^3.726.1",
+    "@aws-sdk/client-s3": "3.726.1",
     "@aws-sdk/s3-request-presigner": "^3.693.0",
     "@convex-dev/action-retrier": "^0.1.5",
     "convex-helpers": "^0.1.67",


### PR DESCRIPTION
<!-- Describe your PR here. -->
Hello there is a known issue with aws sdk when used from cloudflare workers, making the component not useable as it throws

`[TypeError: e.getReader is not a function]`

Issue and workaround is described here: https://github.com/aws/aws-sdk-js-v3/issues/6834#issuecomment-2757283899


<img width="1019" alt="Screenshot 2025-06-26 at 1 38 00 AM" src="https://github.com/user-attachments/assets/63824d10-afa1-4d0f-837e-feaa59b1da55" />

<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
