### PR TITLE
Lazy S3Client initialization, rename r2 getter to client

### DIFF
--- a/src/client/index.test.ts
+++ b/src/client/index.test.ts
@@ -9,22 +9,35 @@ describe("R2 lazy initialization", () => {
     expect(() => new R2(mockComponent)).not.toThrow();
   });
 
-  it("throws with descriptive error when accessing r2 getter with missing config", () => {
-    const r2 = new R2(mockComponent);
+  it("throws with descriptive error when accessing client with missing config", () => {
+    const client = new R2(mockComponent);
 
-    expect(() => r2.r2).toThrow("R2 configuration is missing required fields");
-    expect(() => r2.r2).toThrow("R2_BUCKET");
+    expect(() => client.client).toThrow(
+      "R2 configuration is missing required fields",
+    );
+    expect(() => client.client).toThrow("R2_BUCKET");
   });
 
   it("creates S3Client when config is provided via options", () => {
-    const r2 = new R2(mockComponent, {
+    const client = new R2(mockComponent, {
       R2_BUCKET: "test-bucket",
       R2_ENDPOINT: "https://test.r2.cloudflarestorage.com",
       R2_ACCESS_KEY_ID: "test-key",
       R2_SECRET_ACCESS_KEY: "test-secret",
     });
 
-    expect(r2.config.bucket).toBe("test-bucket");
-    expect(() => r2.r2).not.toThrow();
+    expect(client.config.bucket).toBe("test-bucket");
+    expect(() => client.client).not.toThrow();
+  });
+
+  it("exposes deprecated r2 getter as alias for client", () => {
+    const client = new R2(mockComponent, {
+      R2_BUCKET: "test-bucket",
+      R2_ENDPOINT: "https://test.r2.cloudflarestorage.com",
+      R2_ACCESS_KEY_ID: "test-key",
+      R2_SECRET_ACCESS_KEY: "test-secret",
+    });
+
+    expect(client.r2).toBe(client.client);
   });
 });

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -95,13 +95,23 @@ type RunActionCtx = {
 
 export class R2 {
   public readonly config: Infer<typeof r2ConfigValidator>;
-  private _r2: S3Client | undefined;
+  private _client: S3Client | undefined;
 
-  get r2(): S3Client {
-    if (!this._r2) {
-      this._r2 = createR2Client(parseConfig(this.config));
+  /**
+   * The configured S3Client for direct access to the R2 bucket.
+   */
+  get client(): S3Client {
+    if (!this._client) {
+      this._client = createR2Client(parseConfig(this.config));
     }
-    return this._r2;
+    return this._client;
+  }
+
+  /**
+   * @deprecated Use `client` instead.
+   */
+  get r2(): S3Client {
+    return this.client;
   }
 
   /**
@@ -157,7 +167,7 @@ export class R2 {
   async getUrl(key: string, options: { expiresIn?: number } = {}) {
     const { expiresIn = 900 } = options;
     return await getSignedUrl(
-      this.r2,
+      this.client,
       new GetObjectCommand({ Bucket: this.config.bucket, Key: key }),
       { expiresIn },
     );
@@ -173,7 +183,7 @@ export class R2 {
   async generateUploadUrl(customKey?: string) {
     const key = customKey || crypto.randomUUID();
     const url = await getSignedUrl(
-      this.r2,
+      this.client,
       new PutObjectCommand({ Bucket: this.config.bucket, Key: key }),
     );
     return { key, url };
@@ -225,7 +235,7 @@ export class R2 {
       ContentType: opts.type || fileType,
       ContentDisposition: opts.disposition,
     });
-    await this.r2.send(command);
+    await this.client.send(command);
     await ctx.runAction(this.component.lib.syncMetadata, {
       key: key,
       ...this.config,


### PR DESCRIPTION
## Summary

- Defer S3Client creation and config validation to first access, unblocking local dev/tests/CI when R2 env vars aren't set
- Rename the S3Client accessor from `r2` to `client` (so it's `r2.client` instead of `r2.r2`)
- Keep a deprecated `r2` getter alias for backwards compatibility
- Add tests for lazy initialization behavior

Fixes #19

## Details

The `R2` class constructor previously called `parseConfig()` and `createR2Client()` eagerly, throwing at module load time if any of `R2_BUCKET`, `R2_ENDPOINT`, `R2_ACCESS_KEY_ID`, or `R2_SECRET_ACCESS_KEY` were missing.

Changes to `src/client/index.ts`:

- `config` stays as an eagerly-assigned `public readonly` property (no validation at construction)
- New `client` getter — `parseConfig()` and `createR2Client()` run on first access
- Deprecated `r2` getter delegates to `client` for backwards compatibility
- The "R2 configuration is missing required fields" error message is preserved — it runs on first use instead of construction

New `src/client/index.test.ts`:

- Construction without env vars doesn't throw
- Accessing `client` with missing config throws descriptive error
- Valid config creates S3Client
- Deprecated `r2` getter returns same instance as `client`

## Test plan

- [x] `npm test` — 5 tests pass, 0 type errors
- [x] `npm run build` passes
- [x] Example app validated end-to-end (image gallery, upload, metadata sync)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * R2 storage client now initializes lazily on first access; deprecated alias retained for compatibility.
* **Tests**
  * Added tests covering lazy initialization, behavior with missing configuration (clear error messaging), and the deprecated alias functioning as an alias.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->