### PR TITLE
Add clean option names, deprecate env-var-style names

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,9 +94,33 @@ npx convex env set R2_ENDPOINT xxxxx
 npx convex env set R2_BUCKET xxxxx
 ```
 
-Note: All of these values can also be supplied as the second argument to `R2`.
-This enables storing values in multiple buckets using the same component. It
-also enables dynamically setting the values at runtime.
+Note: Environment variables are only needed if you don't pass config directly
+to the `R2` constructor. You can also pass individual values to override
+specific environment variables.
+
+### Using multiple buckets
+
+To use multiple R2 buckets, create separate `R2` instances with different
+config:
+
+```ts
+import { R2 } from "@convex-dev/r2";
+import { components } from "./_generated/api";
+
+// Primary bucket — reads from R2_* environment variables
+const primary = new R2(components.r2);
+
+// Archive bucket — configured explicitly
+const archive = new R2(components.r2, {
+  bucket: process.env.ARCHIVE_BUCKET!,
+  endpoint: process.env.ARCHIVE_ENDPOINT!,
+  accessKeyId: process.env.ARCHIVE_ACCESS_KEY_ID!,
+  secretAccessKey: process.env.ARCHIVE_SECRET_ACCESS_KEY!,
+});
+```
+
+Each instance maintains its own config and S3 client. Metadata from all
+buckets coexists in the same Convex table, indexed by bucket name.
 
 ## Uploading files
 

--- a/src/client/index.test.ts
+++ b/src/client/index.test.ts
@@ -18,7 +18,7 @@ describe("R2 lazy initialization", () => {
     expect(() => client.client).toThrow("R2_BUCKET");
   });
 
-  it("creates S3Client when config is provided via options", () => {
+  it("creates S3Client when config is provided via deprecated option names", () => {
     const client = new R2(mockComponent, {
       R2_BUCKET: "test-bucket",
       R2_ENDPOINT: "https://test.r2.cloudflarestorage.com",
@@ -30,12 +30,49 @@ describe("R2 lazy initialization", () => {
     expect(() => client.client).not.toThrow();
   });
 
+  it("creates S3Client when config is provided via clean option names", () => {
+    const client = new R2(mockComponent, {
+      bucket: "test-bucket",
+      endpoint: "https://test.r2.cloudflarestorage.com",
+      accessKeyId: "test-key",
+      secretAccessKey: "test-secret",
+    });
+
+    expect(client.config.bucket).toBe("test-bucket");
+    expect(client.config.endpoint).toBe(
+      "https://test.r2.cloudflarestorage.com",
+    );
+    expect(client.config.accessKeyId).toBe("test-key");
+    expect(client.config.secretAccessKey).toBe("test-secret");
+    expect(() => client.client).not.toThrow();
+  });
+
+  it("clean option names take precedence over deprecated names", () => {
+    const client = new R2(mockComponent, {
+      bucket: "clean-bucket",
+      endpoint: "https://clean.r2.cloudflarestorage.com",
+      accessKeyId: "clean-key",
+      secretAccessKey: "clean-secret",
+      R2_BUCKET: "deprecated-bucket",
+      R2_ENDPOINT: "https://deprecated.r2.cloudflarestorage.com",
+      R2_ACCESS_KEY_ID: "deprecated-key",
+      R2_SECRET_ACCESS_KEY: "deprecated-secret",
+    });
+
+    expect(client.config.bucket).toBe("clean-bucket");
+    expect(client.config.endpoint).toBe(
+      "https://clean.r2.cloudflarestorage.com",
+    );
+    expect(client.config.accessKeyId).toBe("clean-key");
+    expect(client.config.secretAccessKey).toBe("clean-secret");
+  });
+
   it("exposes deprecated r2 getter as alias for client", () => {
     const client = new R2(mockComponent, {
-      R2_BUCKET: "test-bucket",
-      R2_ENDPOINT: "https://test.r2.cloudflarestorage.com",
-      R2_ACCESS_KEY_ID: "test-key",
-      R2_SECRET_ACCESS_KEY: "test-secret",
+      bucket: "test-bucket",
+      endpoint: "https://test.r2.cloudflarestorage.com",
+      accessKeyId: "test-key",
+      secretAccessKey: "test-secret",
     });
 
     expect(client.r2).toBe(client.client);


### PR DESCRIPTION
## Summary

- Adds `bucket`, `endpoint`, `accessKeyId`, `secretAccessKey` as primary constructor option names
- Deprecates old `R2_BUCKET`-style option names (still supported for backwards compatibility)
- Updates error message to reference both config field names and env var names
- Adds multi-bucket documentation section to README

Fixes #17

## Details

The old option names (`R2_BUCKET`, `R2_ENDPOINT`, etc.) look like env var names, which is confusing for multi-bucket setups. The new names match the internal config fields and make it clear these are config values, not env var references.

Resolution order: clean option → deprecated option → env var.

## Test plan

- [x] Existing tests pass with deprecated option names (backwards compat)
- [x] New test verifies clean option names work
- [x] New test verifies clean names take precedence over deprecated names
- [x] All 7 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new configuration options (bucket, endpoint, accessKeyId, secretAccessKey) directly in the R2 constructor for per-instance configuration.
  * Added documentation example demonstrating how to create and manage multiple R2 instances with distinct configurations.

* **Improvements**
  * Configuration now respects precedence: direct constructor options override environment variables. Deprecated option names remain supported for backward compatibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->