### PR TITLE
Support CacheControl option in store() method

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,11 +292,13 @@ export const store = internalAction({
     // syncs the metadata, and returns the key. The key is a uuid by default, but
     // an optional custom key can be provided in the options object. A MIME type
     // can also be provided, which will override the type inferred for blobs. A
-    // Content-Disposition can also be provided if necessary.
+    // Content-Disposition and Cache-Control header can also be provided if
+    // necessary.
     const key = await r2.store(ctx, blob, {
       key: "my-custom-key",
       type: "image/jpeg",
-      disposition: "attachment; filename=example.jpg"
+      disposition: "attachment; filename=example.jpg",
+      cacheControl: "max-age=3600",
     });
 
     // Example use case, associate the key with a record in your database

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -214,13 +214,14 @@ export class R2 {
    *   - `key`          - A custom R2 object key to use (uuid if not provided).
    *   - `type`         - The MIME type of the blob (will be inferred if not provided).
    *   - `disposition`  - The ContentDisposition header to let the browser know how to handle the file.
+   *   - `cacheControl` - The Cache-Control header to set on the object (e.g. "max-age=3600").
    * @returns A promise that resolves to the key of the stored object.
    */
 
   async store(
     ctx: RunActionCtx,
     file: Uint8Array | Buffer | Blob,
-    opts: string | { key?: string; type?: string; disposition?: string, } = {},
+    opts: string | { key?: string; type?: string; disposition?: string; cacheControl?: string } = {},
   ) {
     if (typeof opts === "string") {
       opts = { key: opts };
@@ -250,6 +251,7 @@ export class R2 {
       Body: parsedFile,
       ContentType: opts.type || fileType,
       ContentDisposition: opts.disposition,
+      CacheControl: opts.cacheControl,
     });
     await this.client.send(command);
     await ctx.runAction(this.component.lib.syncMetadata, {


### PR DESCRIPTION
## Summary
- Adds a `cacheControl` option to the `store()` method, allowing users to set the `Cache-Control` header on R2 objects at upload time
- Passes the value through as `CacheControl` on the `PutObjectCommand`
- Updates README with example usage

Closes #21

## Test plan
- [x] TypeScript compilation passes (`npx tsc --noEmit`)
- [ ] Verify `Cache-Control` header is set on uploaded R2 object by uploading with `cacheControl: "max-age=3600"` and inspecting object metadata in the Cloudflare dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added support for optional Cache-Control header configuration in R2 storage operations, enabling control over caching behavior for stored objects.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->