### PR TITLE
mark framework peer deps as optional

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,6 +74,12 @@
     "react-dom": "^18 || ^19",
     "svelte": ">=5.0.0"
   },
+  "peerDependenciesMeta": {
+    "convex-svelte": { "optional": true },
+    "react": { "optional": true },
+    "react-dom": { "optional": true },
+    "svelte": { "optional": true }
+  },
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.18.0",
     "@convex-dev/eslint-plugin": "^1.0.0",


### PR DESCRIPTION
React/Svelte peer deps incorrectly required for all users. Marks them optional via peerDependenciesMeta.