### PR TITLE
chore: standardize package.json scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,14 +18,8 @@
     "dev": "run-p -r 'dev:*'",
     "dev:backend": "convex dev --typecheck-components",
     "dev:frontend": "cd example && vite --clearScreen false",
-<<<<<<< Updated upstream
-    "dev:build": "chokidar 'tsconfig*.json' 'src/**/*.ts' -i '**/*.test.ts' -c 'npx convex codegen --component-dir ./src/component && npm run build' --initial",
-    "predev": "path-exists .env.local || (npm run build && convex dev --until-success)",
-    "clean": "rm -rf dist *.tsbuildinfo",
-=======
     "dev:build": "chokidar 'tsconfig*.json' 'src/**/*.ts' -i '**/*.test.ts' -c 'npm run build:codegen' --initial",
-    "predev": "path-exists .env.local dist || (npm run build && convex dev --once)",
->>>>>>> Stashed changes
+    "predev": "path-exists .env.local || (npm run build && convex dev --until-success)",
     "build": "tsc --project ./tsconfig.build.json",
     "build:codegen": "npx convex codegen --component-dir ./src/component && npm run build",
     "build:clean": "rm -rf dist *.tsbuildinfo && npm run build:codegen",
@@ -36,18 +30,11 @@
     "test:watch": "vitest --typecheck --clearScreen false",
     "test:debug": "vitest --inspect-brk --no-file-parallelism",
     "test:coverage": "vitest run --coverage --coverage.reporter=text",
-<<<<<<< Updated upstream
-    "prepublishOnly": "npm run clean && npm run build",
-    "preversion": "npm run clean && npm ci && npm run build && run-p test lint typecheck",
-    "alpha": "npm version prerelease --preid alpha && npm publish --tag alpha && git push --follow-tags",
-    "release": "npm version patch && npm publish && git push --follow-tags",
-    "release:minor": "npm version minor && npm publish && git push --follow-tags",
-=======
     "preversion": "npm ci && npm run build:clean && run-p test lint typecheck",
     "prepublishOnly": "npm whoami || npm login",
     "alpha": "npm version prerelease --preid alpha && npm publish --tag alpha && git push --follow-tags",
     "release": "npm version patch && npm publish && git push --follow-tags",
->>>>>>> Stashed changes
+    "release:minor": "npm version minor && npm publish && git push --follow-tags",
     "version": "vim -c 'normal o' -c 'normal o## '$npm_package_version CHANGELOG.md && prettier -w CHANGELOG.md && git add CHANGELOG.md"
   },
   "files": [


### PR DESCRIPTION
## Summary
- Add build:codegen and build:clean scripts
- Update dev:build to use npm run build:codegen
- Standardize predev with path-exists check
- Add preversion and prepublishOnly hooks
- Simplify alpha/release scripts
- Update version script to use vim pattern

Aligning with the template-component pattern.