### PR TITLE
fix: keep action ctx assignable to client ctx types on convex >= 1.41

### DIFF
--- a/src/client/ctx.test-d.ts
+++ b/src/client/ctx.test-d.ts
@@ -1,0 +1,33 @@
+import type {
+  GenericActionCtx,
+  GenericDataModel,
+  GenericMutationCtx,
+  GenericQueryCtx,
+} from "convex/server";
+import type { R2 } from "./index.js";
+
+// Regression test for the ctx helper types: runQuery/runMutation on
+// query/mutation ctxs gained an extra optional options argument in convex
+// 1.41.0 that action ctxs don't have, which broke passing an action ctx to
+// store/syncMetadata/deleteObject. Hand-rolling the minimal signature per
+// method keeps every ctx variant assignable. Plain assignments (rather than
+// expectTypeOf) because they exercise the exact relation used at real call
+// sites.
+declare const queryCtx: GenericQueryCtx<GenericDataModel>;
+declare const mutationCtx: GenericMutationCtx<GenericDataModel>;
+declare const actionCtx: GenericActionCtx<GenericDataModel>;
+
+type GetMetadataCtx = Parameters<R2["getMetadata"]>[0];
+export const queryCtxReadsMetadata: GetMetadataCtx = queryCtx;
+export const mutationCtxReadsMetadata: GetMetadataCtx = mutationCtx;
+export const actionCtxReadsMetadata: GetMetadataCtx = actionCtx;
+
+type DeleteObjectCtx = Parameters<R2["deleteObject"]>[0];
+export const mutationCtxDeletesObjects: DeleteObjectCtx = mutationCtx;
+export const actionCtxDeletesObjects: DeleteObjectCtx = actionCtx;
+
+type StoreCtx = Parameters<R2["store"]>[0];
+export const actionCtxStores: StoreCtx = actionCtx;
+
+type SyncMetadataCtx = Parameters<R2["syncMetadata"]>[0];
+export const actionCtxSyncsMetadata: SyncMetadataCtx = actionCtx;

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -1,8 +1,9 @@
 import {
   type ApiFromModules,
   createFunctionHandle,
+  type FunctionArgs,
   type FunctionReference,
-  type GenericActionCtx,
+  type FunctionReturnType,
   type GenericDataModel,
   type GenericMutationCtx,
   type GenericQueryCtx,
@@ -81,17 +82,27 @@ export type ClientApi = ApiFromModules<{
 }>["client"];
 
 // e.g. `ctx` from a Convex mutation or action.
+// Hand-rolled minimal signatures instead of indexing into
+// GenericQueryCtx/GenericMutationCtx: those gained an extra optional options
+// argument in convex 1.41.0 that GenericActionCtx doesn't have, which would
+// make action ctx no longer assignable here.
 type RunQueryCtx = {
-  runQuery: GenericQueryCtx<GenericDataModel>["runQuery"];
+  runQuery: <Query extends FunctionReference<"query", "internal">>(
+    query: Query,
+    args: FunctionArgs<Query>
+  ) => Promise<FunctionReturnType<Query>>;
 };
-type RunMutationCtx = {
-  runQuery: GenericQueryCtx<GenericDataModel>["runQuery"];
-  runMutation: GenericMutationCtx<GenericDataModel>["runMutation"];
+type RunMutationCtx = RunQueryCtx & {
+  runMutation: <Mutation extends FunctionReference<"mutation", "internal">>(
+    mutation: Mutation,
+    args: FunctionArgs<Mutation>
+  ) => Promise<FunctionReturnType<Mutation>>;
 };
-type RunActionCtx = {
-  runAction: GenericActionCtx<GenericDataModel>["runAction"];
-  runQuery: GenericQueryCtx<GenericDataModel>["runQuery"];
-  runMutation: GenericMutationCtx<GenericDataModel>["runMutation"];
+type RunActionCtx = RunMutationCtx & {
+  runAction: <Action extends FunctionReference<"action", "internal">>(
+    action: Action,
+    args: FunctionArgs<Action>
+  ) => Promise<FunctionReturnType<Action>>;
 };
 
 export class R2 {

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -1,9 +1,8 @@
 import {
   type ApiFromModules,
   createFunctionHandle,
-  type FunctionArgs,
   type FunctionReference,
-  type FunctionReturnType,
+  type GenericActionCtx,
   type GenericDataModel,
   type GenericMutationCtx,
   type GenericQueryCtx,
@@ -81,29 +80,20 @@ export type ClientApi = ApiFromModules<{
   client: ReturnType<R2["clientApi"]>;
 }>["client"];
 
-// e.g. `ctx` from a Convex mutation or action.
-// Hand-rolled minimal signatures instead of indexing into
-// GenericQueryCtx/GenericMutationCtx: those gained an extra optional options
-// argument in convex 1.41.0 that GenericActionCtx doesn't have, which would
-// make action ctx no longer assignable here.
-type RunQueryCtx = {
-  runQuery: <Query extends FunctionReference<"query", "internal">>(
-    query: Query,
-    args: FunctionArgs<Query>
-  ) => Promise<FunctionReturnType<Query>>;
-};
-type RunMutationCtx = RunQueryCtx & {
-  runMutation: <Mutation extends FunctionReference<"mutation", "internal">>(
-    mutation: Mutation,
-    args: FunctionArgs<Mutation>
-  ) => Promise<FunctionReturnType<Mutation>>;
-};
-type RunActionCtx = RunMutationCtx & {
-  runAction: <Action extends FunctionReference<"action", "internal">>(
-    action: Action,
-    args: FunctionArgs<Action>
-  ) => Promise<FunctionReturnType<Action>>;
-};
+// e.g. `ctx` from a Convex query, mutation, or action. Unions of ctx types
+// picked from the real ctx variants, so signatures match the types callers
+// actually provide. Indexing into a single ctx type broke on convex 1.41.0,
+// which added an extra optional options argument to runQuery/runMutation on
+// query/mutation ctxs but not action ctxs.
+type QueryCtx = Pick<GenericQueryCtx<GenericDataModel>, "runQuery">;
+type MutationCtx = Pick<
+  GenericMutationCtx<GenericDataModel>,
+  "runQuery" | "runMutation"
+>;
+type ActionCtx = Pick<
+  GenericActionCtx<GenericDataModel>,
+  "runQuery" | "runMutation" | "runAction"
+>;
 
 export class R2 {
   public readonly config: Infer<typeof r2ConfigValidator>;
@@ -230,7 +220,7 @@ export class R2 {
    */
 
   async store(
-    ctx: RunActionCtx,
+    ctx: ActionCtx,
     file: Uint8Array | Buffer | Blob,
     opts: string | { key?: string; type?: string; disposition?: string; cacheControl?: string } = {},
   ) {
@@ -279,7 +269,7 @@ export class R2 {
    * @param key - The R2 object key.
    * @returns A promise that resolves when the metadata is synced.
    */
-  async syncMetadata(ctx: RunActionCtx, key: string) {
+  async syncMetadata(ctx: ActionCtx, key: string) {
     await ctx.runAction(this.component.lib.syncMetadata, {
       key: key,
       ...this.config,
@@ -292,7 +282,7 @@ export class R2 {
    * @param key - The R2 object key.
    * @returns A promise that resolves to the metadata for the object.
    */
-  async getMetadata(ctx: RunQueryCtx, key: string) {
+  async getMetadata(ctx: QueryCtx | MutationCtx | ActionCtx, key: string) {
     return ctx.runQuery(this.component.lib.getMetadata, {
       key: key,
       ...this.config,
@@ -305,7 +295,7 @@ export class R2 {
    * @param limit (optional) - The maximum number of documents to return.
    * @returns A promise that resolves to an array of metadata documents.
    */
-  async listMetadata(ctx: RunQueryCtx, limit?: number, cursor?: string | null) {
+  async listMetadata(ctx: QueryCtx | MutationCtx | ActionCtx, limit?: number, cursor?: string | null) {
     return ctx.runQuery(this.component.lib.listMetadata, {
       ...this.config,
       limit: limit,
@@ -319,7 +309,7 @@ export class R2 {
    * @param key - The R2 object key.
    * @returns A promise that resolves when the object is deleted.
    */
-  async deleteObject(ctx: RunMutationCtx, key: string) {
+  async deleteObject(ctx: MutationCtx | ActionCtx, key: string) {
     await ctx.runMutation(this.component.lib.deleteObject, {
       key: key,
       ...this.config,

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,7 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "include": ["src/**/*"],
-  "exclude": ["src/**/*.test.*", "./src/test.ts"],
+  "exclude": ["src/**/*.test.*", "src/**/*.test-d.*", "./src/test.ts"],
   "compilerOptions": {
     "module": "ESNext",
     "moduleResolution": "Bundler"


### PR DESCRIPTION
Fixes #66

convex 1.41.0 added an optional options argument (`transactionLimits`) to `runQuery`/`runMutation` on `GenericQueryCtx`/`GenericMutationCtx`, but not on `GenericActionCtx`. Since the client's `RunQueryCtx`/`RunMutationCtx`/`RunActionCtx` index into the query/mutation ctx types, an action ctx is no longer assignable to them — `r2.store(ctx, ...)`, `r2.syncMetadata(ctx, ...)`, and `r2.deleteObject(ctx, ...)` fail to typecheck when called from an action on convex ≥ 1.41.0. Runtime behavior is unaffected.

This replaces the indexed types with hand-rolled minimal signatures — the same pattern `@convex-dev/workpool` uses — which keeps every ctx variant assignable on both convex < 1.41 and ≥ 1.41.

Also adds a type-level regression test (`ctx.test-d.ts`). It uses plain assignments rather than `expectTypeOf().toExtend()`, since the latter checks a more lenient relation and doesn't catch this incompatibility. `*.test-d.*` is excluded from `tsconfig.build.json` so the test isn't emitted to dist.

Verified `npm run typecheck` and `npm test` pass on the repo's pinned convex (1.35.1) and on convex 1.41.0; on 1.41.0 the new test fails without the fix.