### PR TITLE
fix: widen convex-svelte peer dependency to include 0.13.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
   },
   "peerDependencies": {
     "convex": "^1.24.8",
-    "convex-svelte": "^0.0.11 || ^0.0.12",
+    "convex-svelte": "^0.0.11 || ^0.0.12 || ^0.13.0",
     "convex-vue": "^0.1.5",
     "react": "^18 || ^19",
     "react-dom": "^18 || ^19",


### PR DESCRIPTION
## Summary

`@convex-dev/r2` declares its `convex-svelte` peer dependency as `^0.0.11 || ^0.0.12`, but `convex-svelte` is now at `0.13.0`. This produces an unmet-peer warning on every install for Svelte consumers on a current `convex-svelte`:

```
✕ unmet peer convex-svelte@"^0.0.11 || ^0.0.12": found 0.13.0
```

This PR widens the peer dependency range to `^0.0.11 || ^0.0.12 || ^0.13.0`.

## Compatibility

The only `convex-svelte` API used by this package is `useConvexClient` (`src/svelte/index.ts`), which is still exported in `convex-svelte@0.13.0` (`src/lib/index.ts`). So the range widening is safe — no source changes are needed.

Note: `convex-svelte@0.13.0` raised its own peer floors to `convex@^1.30.0` and `svelte@^5.19.0`. Those are convex-svelte's own constraints and don't conflict with r2's broader peer ranges; consumers on `convex-svelte@0.13.0` will already satisfy them.

Existing `^0.0.11 || ^0.0.12` entries are kept for backward compatibility.

Fixes #68